### PR TITLE
Match cpu-numbers with more than one digit

### DIFF
--- a/intel-power-control
+++ b/intel-power-control
@@ -103,7 +103,7 @@ class IntelPowerControl(QWidget):
         layout = QHBoxLayout()
         self.cpulabels = {}
         cpus = [ c for c in os.listdir(self.cpubasepath)
-                 if re.match( r'^cpu\d$', c) ]
+                 if re.match( r'^cpu\d+$', c) ]
         self.cpumapper = QSignalMapper()
         for i in sorted(cpus):
             l = QPushButton(i)


### PR DESCRIPTION
Previous regex did match cpu0 to cpu9 only.
Now regex matches cpu's with one or more digits (`d+`).

Fixes #5 .